### PR TITLE
fix: Pre-populate known keys with non-default key mappings

### DIFF
--- a/common/src/main/java/net/blay09/mods/defaultoptions/keys/KeyMappingDefaultsHandler.java
+++ b/common/src/main/java/net/blay09/mods/defaultoptions/keys/KeyMappingDefaultsHandler.java
@@ -78,6 +78,12 @@ public class KeyMappingDefaultsHandler implements DefaultOptionsHandler {
         defaultKeys.clear();
         knownKeys.clear();
 
+        for (KeyMapping keyMapping : Minecraft.getInstance().options.keyMappings) {
+            if (!keyMapping.isDefault()) {
+                knownKeys.add(keyMapping.getName());
+            }
+        }
+
         // Load the default keys from the config
         File defaultKeysFile = new File(DefaultOptions.getDefaultOptionsFolder(), "keybindings.txt");
         if (defaultKeysFile.exists()) {


### PR DESCRIPTION
This pr will fix: https://github.com/OrzMiku/lunarfox/issues/21